### PR TITLE
fix handling of added special tokens in tokenizers

### DIFF
--- a/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_bert.py
+++ b/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_bert.py
@@ -11,3 +11,4 @@ def set_bert_vocab(tokenizer: BertTokenizer, vocab: Dict[str, int]) -> None:
     tokenizer.ids_to_tokens = collections.OrderedDict([(ids, tok) for tok, ids in vocab.items()])
     tokenizer.vocab = vocab
     tokenizer.wordpiece_tokenizer.vocab = vocab
+    tokenizer.added_tokens_encoder = {k: vocab[k] for k in tokenizer.added_tokens_encoder.keys()}

--- a/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_fast_tokenizer.py
+++ b/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_fast_tokenizer.py
@@ -50,7 +50,8 @@ def set_unigram_vocab(tokenizer_obj: Dict[str, Any], vocab: Dict[str, int]) -> N
     # hence we don't delete tokens, but reorder them, so that the ids fit the requirement.
     n = len(vocab)
 
-    # special tokens will be added to the end (and therefore have a wrong id) if they are not explicitely also in the vocab.
+    # special tokens will be added to the end (and therefore have a wrong id)
+    # if they are not explicitely also in the vocab.
     registered_tokens = {token for token, _ in tokenizer_obj["model"]["vocab"]}
     for special_token in tokenizer_obj["added_tokens"]:
         if special_token["content"] not in registered_tokens:

--- a/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_fast_tokenizer.py
+++ b/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_fast_tokenizer.py
@@ -49,6 +49,13 @@ def set_unigram_vocab(tokenizer_obj: Dict[str, Any], vocab: Dict[str, int]) -> N
     # unigram tokenizer save scores next to the vocabulary and requires other tokens for intermediate tokenization.
     # hence we don't delete tokens, but reorder them, so that the ids fit the requirement.
     n = len(vocab)
+
+    # special tokens will be added to the end (and therefore have a wrong id) if they are not explicitely also in the vocab.
+    registered_tokens = {token for token, _ in tokenizer_obj["model"]["vocab"]}
+    for special_token in tokenizer_obj["added_tokens"]:
+        if special_token["content"] not in registered_tokens:
+            tokenizer_obj["model"]["vocab"].append((special_token["content"], 0.0))
+
     tokenizer_obj["model"]["vocab"] = sorted(tokenizer_obj["model"]["vocab"], key=lambda x: vocab.get(x[0], n))
 
 

--- a/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_roberta.py
+++ b/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_roberta.py
@@ -9,3 +9,4 @@ from transformer_smaller_training_vocab.transformer_set_vocab.auto_set_vocab imp
 def set_roberta_vocab(tokenizer: RobertaTokenizer, vocab: Dict[str, int]) -> None:
     tokenizer.encoder = vocab
     tokenizer.decoder = {v: k for k, v in vocab.items()}
+    tokenizer.added_tokens_encoder = {k: vocab[k] for k in tokenizer.added_tokens_encoder.keys()}

--- a/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_xlm_roberta.py
+++ b/transformer_smaller_training_vocab/transformer_set_vocab/set_vocab_xlm_roberta.py
@@ -9,3 +9,4 @@ from transformer_smaller_training_vocab.transformer_set_vocab.auto_set_vocab imp
 def set_xlm_roberta_vocab(tokenizer: XLMRobertaTokenizer, vocab: Dict[str, int]) -> None:
     tokenizer.fairseq_tokens_to_ids = vocab
     tokenizer.fairseq_ids_to_tokens = {v: k for k, v in tokenizer.fairseq_tokens_to_ids.items()}
+    tokenizer.added_tokens_encoder = {k: vocab[k] for k in tokenizer.added_tokens_encoder.keys()}


### PR DESCRIPTION
Adding special tokens via `tokenizer.add_special_tokens({"additional_special_tokens": added_tokens})` adds special tokens to the end.
For some tokenizers, the ids were not updated and therefore resulted in index errors when used.

This PR correctly updates the ids of the special tokens for all implemented tokenizers