### PR TITLE
Fix version constrain for torch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/helpmefindaname/transformer-smaller-training-vo
 [tool.poetry.dependencies]
 python = "^3.8"
 transformers = { version = "^4.1", extras = ["torch"] }
-torch = ">=1.8.0 <3.0.0,!=2.0.1"
+torch = ">=1.8.0,<3.0.0,!=2.0.1"
 sentencepiece = "^0.1.97"
 
 [tool.poetry.group.datasets.dependencies]


### PR DESCRIPTION
That was raised in
https://github.com/conda/grayskull/issues/482

But I realised that it was a problem upstream, so, this is a small fix to get the version correctly.