### PR TITLE
fix: import requires_backends from transformers utils package

### DIFF
--- a/transformer_smaller_training_vocab/utils.py
+++ b/transformer_smaller_training_vocab/utils.py
@@ -1,8 +1,9 @@
 from collections.abc import Iterator
 from typing import Union, cast
 
-from transformers import is_datasets_available, requires_backends
+from transformers import is_datasets_available
 from transformers.tokenization_utils_base import PreTokenizedInput, PreTokenizedInputPair, TextInput, TextInputPair
+from transformers.utils import requires_backends
 
 if is_datasets_available():
     from datasets import Dataset, DatasetDict


### PR DESCRIPTION
Hi,

user reported a problem with importing the `requires_backend` function from Transformers, see https://github.com/flairNLP/flair/issues/3672 and #20.

So this PR fixes the problem and imports `requires_backend` from the `utils` package of Transformers.

Tested with latest Transformers version `4.52.4` and in Google Colab.